### PR TITLE
fix: inject Gson instead of creating new instance

### DIFF
--- a/src/main/java/com/afkstatstracker/AfkStatsTrackerPlugin.java
+++ b/src/main/java/com/afkstatstracker/AfkStatsTrackerPlugin.java
@@ -49,12 +49,14 @@ public class AfkStatsTrackerPlugin extends Plugin
 	@Inject
 	private ConfigManager configManager;
 
+	@Inject
+	private Gson gson;
+
 	private SessionHistoryManager sessionHistoryManager;
 
 	@Override
 	protected void startUp() throws Exception
 	{
-		Gson gson = new Gson();
 		SessionHistoryManager.ConfigStorage storage = new SessionHistoryManager.ConfigStorage()
 		{
 			private static final String CONFIG_GROUP = "afkStatsTracker";


### PR DESCRIPTION
## Summary
- Replace `new Gson()` with `@Inject private Gson gson` in `AfkStatsTrackerPlugin`
- Fixes plugin hub build rejection: "Do not create fresh Gson instances, always @Inject the client's Gson"

## Test plan
- [x] `./gradlew build` passes
- [ ] Plugin hub pipeline accepts the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)