### PR TITLE
chore: polish plugin metadata for plugin-hub submission

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,7 @@
 displayName=AFK Stats Tracker
 author=Reasel
-description=Tracks clicks during AFK sessions and computes clicks per hour and consistency stats
+description=Tracks mouse clicks during AFK sessions and computes consistency, average click interval, and average click distance
 tags=afk,stats,tracker,clicks
 plugins=com.afkstatstracker.AfkStatsTrackerPlugin
+version=
 build=standard

--- a/src/main/java/com/afkstatstracker/AfkStatsTrackerPlugin.java
+++ b/src/main/java/com/afkstatstracker/AfkStatsTrackerPlugin.java
@@ -22,7 +22,9 @@ import net.runelite.client.util.ImageUtil;
 
 @Slf4j
 @PluginDescriptor(
-	name = "AFK Stats Tracker"
+	name = "AFK Stats Tracker",
+	description = "Tracks click consistency, interval, and distance during AFK sessions",
+	tags = {"afk", "stats", "tracker", "clicks"}
 )
 public class AfkStatsTrackerPlugin extends Plugin
 {
@@ -89,8 +91,8 @@ public class AfkStatsTrackerPlugin extends Plugin
 
 		clientToolbar.addNavigation(navButton);
 
-        // ponytail: registration is managed per-session in start/stopSession.
-        // Registering here too caused double-registration (double-counted clicks).
+        // Registration is managed per-session in start/stopSession.
+        // Registering here too would double-register the listener (double-counting clicks).
         mouseListener = new MouseClickCounterListener();
 
 	}


### PR DESCRIPTION
Pre-submission polish for the RuneLite plugin-hub:
- Fix `runelite-plugin.properties` description to list the actual metrics (consistency, average click interval, average click distance) instead of the stale "clicks per hour".
- Add empty `version=` key per the plugin-hub template convention.
- Add `description` and `tags` to `@PluginDescriptor` for in-client discoverability.
- Reword an internal code comment.

No functional change; build green.