### PR TITLE
Set version in runelite-plugin.properties

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -3,5 +3,5 @@ author=Reasel
 description=Tracks mouse clicks during AFK sessions and computes consistency, average click interval, and average click distance
 tags=afk,stats,tracker,clicks
 plugins=com.afkstatstracker.AfkStatsTrackerPlugin
-version=
+version=1.1.1
 build=standard


### PR DESCRIPTION
Plugin Hub reads the version from runelite-plugin.properties, not build.gradle. Fills in the empty version= field.