### PR TITLE
Add Copy JSON option to session copy icon

### DIFF
--- a/src/main/java/com/afkstatstracker/AfkStatsTrackerPanel.java
+++ b/src/main/java/com/afkstatstracker/AfkStatsTrackerPanel.java
@@ -308,7 +308,7 @@ public class AfkStatsTrackerPanel extends PluginPanel
 				menu.add(copyStats);
 
 				JMenuItem copyJson = new JMenuItem("Copy JSON");
-				copyJson.addActionListener(a -> copyToClipboard(gson.toJson(session)));
+				copyJson.addActionListener(a -> copyToClipboard(gson.toJson(roundForExport(session))));
 				menu.add(copyJson);
 
 				menu.show(copyIcon, e.getX(), e.getY());
@@ -415,6 +415,19 @@ public class AfkStatsTrackerPanel extends PluginPanel
 	{
 		Toolkit.getDefaultToolkit().getSystemClipboard()
 			.setContents(new StringSelection(text), null);
+	}
+
+	static Session roundForExport(Session session)
+	{
+		return new Session(
+			session.getId(),
+			session.getName(),
+			session.getStartTime(),
+			session.getEndTime(),
+			session.getClickCount(),
+			session.getConsistencyScore(),
+			Math.round(session.getAvgInterval() * 100) / 100.0,
+			Math.round(session.getAvgDistancePercent() * 100) / 100.0);
 	}
 
 	private void makeEditable(JPanel row, Session session, JLabel nameLabel)

--- a/src/main/java/com/afkstatstracker/AfkStatsTrackerPanel.java
+++ b/src/main/java/com/afkstatstracker/AfkStatsTrackerPanel.java
@@ -1,5 +1,6 @@
 package com.afkstatstracker;
 
+import com.google.gson.Gson;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -26,8 +27,10 @@ import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.ImageIcon;
@@ -42,6 +45,7 @@ public class AfkStatsTrackerPanel extends PluginPanel
 {
 	private final AfkStatsTrackerPlugin plugin;
 	private final SessionHistoryManager sessionHistoryManager;
+	private final Gson gson;
 
 	private Timer timer;
 	private JButton startButton;
@@ -60,13 +64,14 @@ public class AfkStatsTrackerPanel extends PluginPanel
 	private JScrollPane historyScrollPane;
 	private boolean historyExpanded = true;
 
-	public AfkStatsTrackerPanel(AfkStatsTrackerPlugin plugin, SessionHistoryManager sessionHistoryManager)
+	public AfkStatsTrackerPanel(AfkStatsTrackerPlugin plugin, SessionHistoryManager sessionHistoryManager, Gson gson)
 	{
 		// wrap=false: we manage our own scroll so the buttons/stats stay pinned and only history data scrolls
 		super(false);
 
 		this.plugin = plugin;
 		this.sessionHistoryManager = sessionHistoryManager;
+		this.gson = gson;
 
 		setLayout(new BorderLayout());
 
@@ -290,24 +295,23 @@ public class AfkStatsTrackerPanel extends PluginPanel
 		// Copy icon
 		JLabel copyIcon = createHoverIcon(
 			new ImageIcon(ImageUtil.loadImageResource(AfkStatsTrackerPanel.class, "copy.png")),
-			"Copy session stats");
+			"Copy session");
 		copyIcon.addMouseListener(new MouseAdapter()
 		{
 			@Override
 			public void mouseClicked(MouseEvent e)
 			{
-				String lengthStr = DurationFormatter.format(session.getEndTime() - session.getStartTime());
+				JPopupMenu menu = new JPopupMenu();
 
-				String text = String.format(
-					"Session: %s\nLength: %s\nConsistency: %d\nAvg Interval: %.0fms\nAvg Distance: %.1f%%\nClicks: %d",
-					session.getName(), lengthStr,
-					session.getConsistencyScore(),
-					session.getAvgInterval(),
-					session.getAvgDistancePercent(),
-					session.getClickCount());
+				JMenuItem copyStats = new JMenuItem("Copy stats");
+				copyStats.addActionListener(a -> copyToClipboard(formatSessionText(session)));
+				menu.add(copyStats);
 
-				Toolkit.getDefaultToolkit().getSystemClipboard()
-					.setContents(new StringSelection(text), null);
+				JMenuItem copyJson = new JMenuItem("Copy JSON");
+				copyJson.addActionListener(a -> copyToClipboard(gson.toJson(session)));
+				menu.add(copyJson);
+
+				menu.show(copyIcon, e.getX(), e.getY());
 			}
 		});
 
@@ -393,6 +397,24 @@ public class AfkStatsTrackerPanel extends PluginPanel
 		icon.setToolTipText(tooltip);
 		icon.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
 		return icon;
+	}
+
+	private String formatSessionText(Session session)
+	{
+		String lengthStr = DurationFormatter.format(session.getEndTime() - session.getStartTime());
+		return String.format(
+			"Session: %s\nLength: %s\nConsistency: %d\nAvg Interval: %.0fms\nAvg Distance: %.1f%%\nClicks: %d",
+			session.getName(), lengthStr,
+			session.getConsistencyScore(),
+			session.getAvgInterval(),
+			session.getAvgDistancePercent(),
+			session.getClickCount());
+	}
+
+	private void copyToClipboard(String text)
+	{
+		Toolkit.getDefaultToolkit().getSystemClipboard()
+			.setContents(new StringSelection(text), null);
 	}
 
 	private void makeEditable(JPanel row, Session session, JLabel nameLabel)

--- a/src/main/java/com/afkstatstracker/AfkStatsTrackerPlugin.java
+++ b/src/main/java/com/afkstatstracker/AfkStatsTrackerPlugin.java
@@ -79,7 +79,7 @@ public class AfkStatsTrackerPlugin extends Plugin
 
 		log.info("AFK Stats Tracker plugin started!");
 
-		panel = new AfkStatsTrackerPanel(this, sessionHistoryManager);
+		panel = new AfkStatsTrackerPanel(this, sessionHistoryManager, gson);
 
 		// Add to toolbar
 		navButton = NavigationButton.builder()

--- a/src/test/java/com/afkstatstracker/SessionJsonTest.java
+++ b/src/test/java/com/afkstatstracker/SessionJsonTest.java
@@ -1,0 +1,32 @@
+package com.afkstatstracker;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SessionJsonTest
+{
+	@Test
+	public void sessionSerializesWithWebsiteContractFieldNames()
+	{
+		Session session = new Session("id-1", "Test", 1000L, 61000L, 42, 87L, 1500.5, 12.3);
+		JsonObject json = new JsonParser().parse(new StringReader(new Gson().toJson(session))).getAsJsonObject();
+
+		assertTrue(json.has("name"));
+		assertTrue(json.has("startTime"));
+		assertTrue(json.has("endTime"));
+		assertTrue(json.has("clickCount"));
+		assertTrue(json.has("consistencyScore"));
+		assertTrue(json.has("avgInterval"));
+		assertTrue(json.has("avgDistancePercent"));
+		assertEquals(42, json.get("clickCount").getAsInt());
+		assertEquals(87L, json.get("consistencyScore").getAsLong());
+		assertEquals(1000L, json.get("startTime").getAsLong());
+	}
+}

--- a/src/test/java/com/afkstatstracker/SessionJsonTest.java
+++ b/src/test/java/com/afkstatstracker/SessionJsonTest.java
@@ -27,4 +27,16 @@ public class SessionJsonTest
 		assertEquals(87L, json.get("consistencyScore").getAsLong());
 		assertEquals(1000L, json.get("startTime").getAsLong());
 	}
+
+	@Test
+	public void roundForExportRoundsFloatsToTwoDecimals()
+	{
+		Session session = new Session("id-1", "Test", 1000L, 61000L, 7, 68L, 521.1666666666666, 4.014945489298668);
+		Session rounded = AfkStatsTrackerPanel.roundForExport(session);
+
+		assertEquals(521.17, rounded.getAvgInterval(), 0.0);
+		assertEquals(4.01, rounded.getAvgDistancePercent(), 0.0);
+		assertEquals(7, rounded.getClickCount());
+		assertEquals(68L, rounded.getConsistencyScore());
+	}
 }

--- a/src/test/java/com/afkstatstracker/SessionJsonTest.java
+++ b/src/test/java/com/afkstatstracker/SessionJsonTest.java
@@ -5,8 +5,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.Test;
 
-import java.io.StringReader;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -16,7 +14,7 @@ public class SessionJsonTest
 	public void sessionSerializesWithWebsiteContractFieldNames()
 	{
 		Session session = new Session("id-1", "Test", 1000L, 61000L, 42, 87L, 1500.5, 12.3);
-		JsonObject json = new JsonParser().parse(new StringReader(new Gson().toJson(session))).getAsJsonObject();
+		JsonObject json = new JsonParser().parse(new Gson().toJson(session)).getAsJsonObject();
 
 		assertTrue(json.has("name"));
 		assertTrue(json.has("startTime"));


### PR DESCRIPTION
## Summary

The copy icon on each session history row now opens a menu with two options:

- **Copy stats**: the existing human-readable text, unchanged
- **Copy JSON**: the session serialized with Gson, for pasting into the afk-stats community site

Adds SessionJsonTest, a contract test that locks the JSON field names the site's API validates (startTime, endTime, clickCount, consistencyScore, avgInterval, avgDistancePercent, name).

Exported JSON rounds avgInterval and avgDistancePercent to two decimals (roundForExport); stored history keeps full precision.

## Testing

- ./gradlew build green (SessionJsonTest x2 plus all existing unit tests)
- Manually verified in the dev client: menu opens, both copies land on the clipboard, JSON matches the contract