### PR TITLE
Add community stats site link to panel and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Use it to compare AFK activities and training methods, the same way you track DP
 
 Session history shows your most recent sessions first. Click a session name to rename it. Sessions can be copied to clipboard or deleted (with confirmation). The Start/Stop buttons and live stats stay pinned in place; only the history list scrolls when it grows long.
 
+## Community Stats Site
+
+Share your sessions and compare against everyone else's at [afk.statstracker.workers.dev](https://afk.statstracker.workers.dev/). Copy a session as JSON from the panel (copy icon → Copy JSON), paste it on the Submit page, and browse charts of consistency, click interval, and distance across activities. The "View community stats" link at the bottom of the plugin panel opens the site.
+
 ## Wiki Guide
 
 See the [AFK Activity Tracker Guide](https://oldschool.runescape.wiki/w/Guide:AFK_Activity_Tracker) on the Old School RuneScape Wiki for a detailed breakdown of the tracked metrics, interactive scatter plots comparing activities, and aggregated averages across activity groups like Bankstanding, Fishing, and Salvaging.

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=AFK Stats Tracker
 author=Reasel
-description=Tracks mouse clicks during AFK sessions and computes consistency, average click interval, and average click distance
+description=Tracks mouse clicks during AFK sessions and computes consistency, average click interval, and average click distance. Compare sessions with others at afk.statstracker.workers.dev
 tags=afk,stats,tracker,clicks
 plugins=com.afkstatstracker.AfkStatsTrackerPlugin
 version=1.1.1

--- a/src/main/java/com/afkstatstracker/AfkStatsTrackerPanel.java
+++ b/src/main/java/com/afkstatstracker/AfkStatsTrackerPanel.java
@@ -39,10 +39,13 @@ import javax.swing.SwingConstants;
 import javax.swing.Timer;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.ui.PluginPanel;
 
 public class AfkStatsTrackerPanel extends PluginPanel
 {
+	private static final String SITE_URL = "https://afk.statstracker.workers.dev/";
+
 	private final AfkStatsTrackerPlugin plugin;
 	private final SessionHistoryManager sessionHistoryManager;
 	private final Gson gson;
@@ -155,6 +158,21 @@ public class AfkStatsTrackerPanel extends PluginPanel
 
 		add(topPanel, BorderLayout.NORTH);
 		add(historyScrollPane, BorderLayout.CENTER);
+
+		JLabel siteLink = new JLabel("View community stats ↗");
+		siteLink.setForeground(ColorScheme.BRAND_ORANGE);
+		siteLink.setBorder(BorderFactory.createEmptyBorder(6, 5, 4, 5));
+		siteLink.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+		siteLink.setToolTipText("Compare your sessions with others at " + SITE_URL);
+		siteLink.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				LinkBrowser.browse(SITE_URL);
+			}
+		});
+		add(siteLink, BorderLayout.SOUTH);
 	}
 
 	private JPanel createStatCard(String title, String tooltip)


### PR DESCRIPTION
## Summary

- Panel footer link "View community stats ↗" (pinned at bottom, opens https://afk.statstracker.workers.dev/ via `LinkBrowser.browse`)
- README: new "Community Stats Site" section describing the copy-JSON-to-Submit flow
- Plugin-hub description now mentions the site

Plugin-hub compliance: the plugin only links out and sends no data to the site. Users submit stats themselves (copy JSON, paste on the site), so RuneLite's third-party-server warning rule does not apply.

I'll refresh the panel screenshot (`panel-preview.png`) in a follow-up.